### PR TITLE
Added authentication with MAL

### DIFF
--- a/MalCoordinator.py
+++ b/MalCoordinator.py
@@ -46,7 +46,7 @@ class MalCoordinator(object):
         return entries
 
 
-    def authenticate(username, password):
+    def authenticate(self, username, password):
         """
         Authenticates username and password with MAL (PS MAL authentication security is fucking terrible wow)
         
@@ -58,15 +58,14 @@ class MalCoordinator(object):
         #TODO: Figure out how not to get banned by MAL for too many incorrect logins??
         from base64 import b64encode
         url = 'https://myanimelist.net/api/account/verify_credentials.xml'
-        encoded_credentials = b64encode(('%s:%s' % (username, password)).encode('utf-8'))
-        r = requests.get(url, headers = {'Authorization': 'Basic %s' % encoded_credentials.decode('utf-8')})
-        if r.status_code == 204:
+        encoded_credentials = b64encode(('%s:%s' % (username, password)).encode('utf-8')).decode('utf-8')
+        r = requests.get(url, headers = {'Authorization': 'Basic %s' % encoded_credentials})
+        if r.status_code in (204, 401):
             return None
         elif r.status_code == 200:
             return encoded_credentials
         else:
-            raise ConnectionRefusedError("MAL Refused Connection, Error Code %s:\tMessage: %s" % (r.status_code. r.text)
-        return encoded_credentials
+            raise ConnectionRefusedError("MAL Refused Connection, Error Code %s:\tMessage: %s" % (r.status_code, r.text))
 
 if __name__ == '__main__':
     coordinator = MalCoordinator()

--- a/MalCoordinator.py
+++ b/MalCoordinator.py
@@ -46,6 +46,20 @@ class MalCoordinator(object):
         return entries
 
 
+    def authenticate(username, password):
+        """
+        Authenticates username and password with MAL (PS MAL authentication security is fucking terrible wow)
+        
+        :returns 'user:password' encoded as base64 string (because this is the only way to save authentication without throwing the poor user's password around thanks to MAL auth scheme lol. Not that this is any safer, but it makes my conscience feel better
+
+        """
+        #TODO: Figure out how not to get banned by MAL for too many incorrect logins??
+        from base64 import b64encode
+        url = 'https://myanimelist.net/api/account/verify_credentials.xml'
+        encoded_credentials = base64.b64encode(('%s:%s' % (username, password)).encode('utf-8'))
+        r = requests.get(url, headers = {'Authorization': 'Basic %s' % encoded_credentials.decode('utf-8')})
+        return r.status_code, encoded_credentials
+
 if __name__ == '__main__':
     coordinator = MalCoordinator()
     for entry in coordinator.fetch_animelist("Silent_Muse"):

--- a/MalCoordinator.py
+++ b/MalCoordinator.py
@@ -51,14 +51,22 @@ class MalCoordinator(object):
         Authenticates username and password with MAL (PS MAL authentication security is fucking terrible wow)
         
         :returns 'user:password' encoded as base64 string (because this is the only way to save authentication without throwing the poor user's password around thanks to MAL auth scheme lol. Not that this is any safer, but it makes my conscience feel better
+        :returns null if authentication fails
+        :throws exception if server communication failed
 
         """
         #TODO: Figure out how not to get banned by MAL for too many incorrect logins??
         from base64 import b64encode
         url = 'https://myanimelist.net/api/account/verify_credentials.xml'
-        encoded_credentials = base64.b64encode(('%s:%s' % (username, password)).encode('utf-8'))
+        encoded_credentials = b64encode(('%s:%s' % (username, password)).encode('utf-8'))
         r = requests.get(url, headers = {'Authorization': 'Basic %s' % encoded_credentials.decode('utf-8')})
-        return r.status_code, encoded_credentials
+        if r.status_code == 204:
+            return None
+        elif r.status_code == 200:
+            return encoded_credentials
+        else:
+            raise ConnectionRefusedError("MAL Refused Connection, Error Code %s:\tMessage: %s" % (r.status_code. r.text)
+        return encoded_credentials
 
 if __name__ == '__main__':
     coordinator = MalCoordinator()


### PR DESCRIPTION
This change allows users to authenticate using their MyAnimeList credentials. 

Unfortunately, it seems that MAL's API will IP block you if you fail too many login attempts. Still working on that. 

The only solution I can think of would be to save the users credentials separately in a database (salted and hashed of course), and authenticate against that first, but even then, that would require that the users at least get their username and password right the first time.